### PR TITLE
Delete activation codes after relink test

### DIFF
--- a/test/src/helpers/user-activation-utils.js
+++ b/test/src/helpers/user-activation-utils.js
@@ -1,10 +1,11 @@
 import EdxActivationRole from '../model/EdxActivationRole';
 import EdxActivationCode from '../model/EdxActivationCode';
-const date = require('date-and-time');
+import date from 'date-and-time';
 
 const userActivationUtils = {
 
-  createEdxActivationCode(isPrimary,roles,activationCode,instituteTypeCode,instituteID){
+const userActivationUtils = {
+  createEdxActivationCode(isPrimary, roles, activationCode, instituteTypeCode, instituteID) {
     const edxActivationCode = new EdxActivationCode();
     edxActivationCode.activationCode = activationCode;
     edxActivationCode.email = 'edx-noreply@gov.bc.ca';
@@ -15,18 +16,20 @@ const userActivationUtils = {
     edxActivationCode.createUser='Automation-Test'
     edxActivationCode.updateUser='Automation-Test'
     const now = new Date();
-    edxActivationCode.expiryDate = date.addDays(now, 1).toJSON().substring(0, 19); //get only first 19 to avoid adding millisecond at the end.
-    if(roles.length>0){
-      for(const role of roles){
+
+    //get only first 19 to avoid adding millisecond at the end.
+    edxActivationCode.expiryDate = date.addDays(now, 1).toJSON().substring(0, 19);
+    if (roles.length > 0) {
+      for (const role of roles) {
         const activationRole = new EdxActivationRole();
-        activationRole.edxRoleCode=role.edxRoleCode;
+        activationRole.edxRoleCode = role.edxRoleCode;
         edxActivationCode.addActivationRole(activationRole);
       }
     }
 
-    if(instituteTypeCode.toString().toUpperCase()=== 'SCHOOL'){
+    if (instituteTypeCode.toString().toUpperCase() === 'SCHOOL') {
       edxActivationCode.schoolID = instituteID;
-    }else if(instituteTypeCode.toString().toUpperCase()=== 'DISTRICT'){
+    } else if (instituteTypeCode.toString().toUpperCase() === 'DISTRICT') {
       edxActivationCode.districtID = instituteID;
     }
     return edxActivationCode;

--- a/test/src/helpers/user-activation-utils.js
+++ b/test/src/helpers/user-activation-utils.js
@@ -2,7 +2,9 @@ import EdxActivationRole from '../model/EdxActivationRole';
 import EdxActivationCode from '../model/EdxActivationCode';
 import date from 'date-and-time';
 
-const userActivationUtils = {
+const restUtils = require('../helpers/rest-utils');
+const { getToken } = require('../helpers/oauth-utils');
+const { edx_api_base_url } = require('../config/constants');
 
 const userActivationUtils = {
   createEdxActivationCode(isPrimary, roles, activationCode, instituteTypeCode, instituteID) {
@@ -33,8 +35,17 @@ const userActivationUtils = {
       edxActivationCode.districtID = instituteID;
     }
     return edxActivationCode;
+  },
+
+  /**
+   * @param {string} userID
+   * @returns {Promise<any>} Response data
+   */
+  async deleteUserActivationCodes(userID) {
+    const { access_token } = await getToken();
+    const endPoint = `${edx_api_base_url}api/v1/edx/users/activation-code/user/${userID}`;
+    return await restUtils.deleteData(access_token, endPoint);
   }
 };
-
 
 module.exports = userActivationUtils;

--- a/test/src/test_cases/edx-user-relink/test-school-user-relink.js
+++ b/test/src/test_cases/edx-user-relink/test-school-user-relink.js
@@ -13,6 +13,7 @@ const {
   deleteSpecificEdxUser,
 } =  require('../../helpers/user-set-up-utils');
 
+const { deleteUserActivationCodes } = require('../../helpers/user-activation-utils');
 
 const loginPage = new LoginPage();
 const usersPage = new AccessUsersPage();
@@ -38,6 +39,7 @@ fixture `school-user-relink`
   .after(async () => {
     log.info('stage:', 'teardown');
     await deleteSetUpEdxUser();
+    await deleteUserActivationCodes(userToRelink.edxUserID);
     await deleteSpecificEdxUser(userToRelink.edxUserID);
   }).beforeEach(async t => {
     await loginPage.login(credentials.adminCredentials);


### PR DESCRIPTION
Jira: EDX-596

This PR implements the new test api endpoint in the `test-school-user-relink` test.  This should help prevent the dev database from getting littered with stale activation codes.