### PR TITLE
Refactor SchoolContact for Vue3

### DIFF
--- a/frontend/src/components/school/SchoolContact.vue
+++ b/frontend/src/components/school/SchoolContact.vue
@@ -4,76 +4,70 @@
       :id="`schoolContactCard-${contact.schoolContactId}`"
       class="schoolContactCard"
       height="100%">
-      <v-card-title class="pb-0">
+      <v-card-title>
         <v-row no-gutters>
-          <v-col>
-            <v-row no-gutters>
-              <v-col cols="8" class="justify-start">
-                <v-icon class="pb-1" small :color="getStatusColor(contact)" left dark>
-                  mdi-circle
-                </v-icon>
-                <strong style="word-break: break-word;">{{ formatContactName(contact) }}</strong>
-              </v-col>
-              <v-col cols="4" class="d-flex justify-end">
-                <v-btn
-                  id="editContactButton"
-                  class="mr-2"
-                  title="Edit"
-                  width="0.5em"
-                  v-if="canEditSchoolContact"
-                  @click="handleOpenEditor"
-                  color="white"
-                  min-width="0.5em"
-                  small
-                  depressed>
-                  <v-icon size="x-large" color="#003366" dark>mdi-pencil</v-icon>
-                </v-btn>
-              </v-col>
-            </v-row>
-            <v-row no-gutters>
-              <v-col v-if="!contact.email && !contact.phoneNumber" cols="12" class="pt-1">
-                <p class="missing-highlight">
-                  <v-icon size="x-large" color="#ff5252" dark>mdi-alert</v-icon>
-                  Missing contact details
-                </p>
-                <a class="editField" @click="handleOpenEditor">+ email or phone</a>
-              </v-col>
-              <v-col v-if="contact.email" cols="12" class="pt-1">
-                <span id="contactEmail"> {{ contact.email }}</span>
-              </v-col>
-              <v-col v-if="contact.phoneNumber" cols="12" class="pt-1">
-                <span id="contactPhoneNumber">{{ formatPhoneNumber(contact.phoneNumber) }}</span>
-                <span v-if="contact.phoneExtension"> ext. {{ contact.phoneExtension }}</span>
-              </v-col>
-              <v-col cols="12" class="pt-1" v-if="contact.alternatePhoneNumber">
-                <span id="contactAlternatePhoneNumber">
-                  {{ formatPhoneNumber(contact.alternatePhoneNumber) }} (alt.)
-                </span>
-                <span v-if="contact.alternatePhoneExtension">
-                  ext. {{ contact.alternatePhoneExtension }}
-                </span>
-              </v-col>
-            </v-row>
+          <v-col cols="8">
+            <v-icon
+              icon="mdi-circle"
+              class="pb-1"
+              size="x-small"
+              :color="getStatusColor(contact)"
+              start />
+              <strong style="word-break: break-word;">{{ formatContactName(contact) }}</strong>
+          </v-col>
+          <v-col cols="4" class="d-flex justify-end">
+            <v-btn
+              id="editContactButton"
+              title="Edit"
+              width="0.5em"
+              v-if="canEditSchoolContact"
+              @click="handleOpenEditor"
+              color="white"
+              min-width="0.5em">
+              <v-icon icon="mdi-pencil" size="x-large" color="#003366" dark />
+            </v-btn>
           </v-col>
         </v-row>
       </v-card-title>
-      <v-card-text class="pt-2">
-        <v-row no-gutters>
-          <v-col cols="12" class="pt-1" v-if="contact.expiryDate">
-            <v-icon aria-hidden="false">
-              mdi-calendar-today
-            </v-icon>
-            <span id="contactEffectiveAndExpiryDate">
+      <v-card-text class="pb-0">
+        <v-list density="compact">
+          <v-list-item v-if="!contact.email && !contact.phoneNumber" class="missing-highlight pl-0">
+            <v-icon icon="mdi-alert" size="x-large" color="#ff5252" dark />
+            Missing contact details
+            <br>
+            <a class="editField" @click="handleOpenEditor">Add email or phone</a>
+          </v-list-item>
+          <v-list-item v-if="contact.email" cols="12" class="pl-0">
+            <v-icon icon="mdi-email" start />
+            <span id="contactEmail"> {{ contact.email }}</span>
+          </v-list-item>
+          <v-list-item v-if="contact.phoneNumber" cols="12" class="pl-0">
+            <v-icon icon="mdi-phone" start />
+            <span id="contactPhoneNumber">{{ formatPhoneNumber(contact.phoneNumber) }}</span>
+            <span v-if="contact.phoneExtension"> ext. {{ contact.phoneExtension }}</span>
+          </v-list-item>
+          <v-list-item cols="12" class="pl-0" v-if="contact.alternatePhoneNumber">
+            <v-icon icon="mdi-phone" start />
+            <span id="contactAlternatePhoneNumber">
+              {{ formatPhoneNumber(contact.alternatePhoneNumber) }} (alt.)
+            </span>
+            <span v-if="contact.alternatePhoneExtension">
+              ext. {{ contact.alternatePhoneExtension }}
+            </span>
+          </v-list-item>
+          <v-list-item cols="12" class="pl-0" v-if="contact.expiryDate">
+            <v-icon icon="mdi-calendar-today" size="small" aria-hidden="false" start />
+            <span id="contactEffectiveAndExpiryDate" class="text-caption">
               {{ formatDate(contact.effectiveDate) }} - {{ formatDate(contact.expiryDate) }}
             </span>
-          </v-col>
-          <v-col cols="12" class="pt-1" v-else>
-            <v-icon aria-hidden="false">
-              mdi-calendar-today
-            </v-icon>
-            <span id="contactEffectiveDate"> {{ formatDate(contact.effectiveDate) }}</span>
-          </v-col>
-        </v-row>
+          </v-list-item>
+          <v-list-item cols="12" class="pl-0" v-else>
+            <v-icon icon="mdi-calendar-today" size="small" aria-hidden="false" start />
+            <span id="contactEffectiveDate" class="text-caption">
+             {{ formatDate(contact.effectiveDate) }}
+            </span>
+          </v-list-item>
+        </v-list>
       </v-card-text>
     </v-card>
   </span>
@@ -111,6 +105,7 @@ export default {
   }
 };
 </script>
+
 <style scoped>
 .editField {
   font-size: 16px;

--- a/frontend/src/components/school/SchoolContact.vue
+++ b/frontend/src/components/school/SchoolContact.vue
@@ -1,6 +1,9 @@
 <template>
   <span>
-    <v-card :id="`schoolContactCard-${contact.schoolContactId}`" class="schoolContactCard" height="100%">
+    <v-card
+      :id="`schoolContactCard-${contact.schoolContactId}`"
+      class="schoolContactCard"
+      height="100%">
       <v-card-title class="pb-0">
         <v-row no-gutters>
           <v-col>
@@ -12,25 +15,26 @@
                 <strong style="word-break: break-word;">{{ formatContactName(contact) }}</strong>
               </v-col>
               <v-col cols="4" class="d-flex justify-end">
-                  <v-btn id="editContactButton"
-                         title="Edit"
-                         color="white"
-                         width="0.5em"
-                         min-width="0.5em"
-                         depressed
-                         v-if="canEditSchoolContact"
-                         @click="handleOpenEditor"
-                         small
-                         class="mr-2">
-                    <v-icon size="x-large" color="#003366" dark>mdi-pencil</v-icon>
-                  </v-btn>
+                <v-btn
+                  id="editContactButton"
+                  class="mr-2"
+                  title="Edit"
+                  width="0.5em"
+                  v-if="canEditSchoolContact"
+                  @click="handleOpenEditor"
+                  color="white"
+                  min-width="0.5em"
+                  small
+                  depressed>
+                  <v-icon size="x-large" color="#003366" dark>mdi-pencil</v-icon>
+                </v-btn>
               </v-col>
             </v-row>
             <v-row no-gutters>
               <v-col v-if="!contact.email && !contact.phoneNumber" cols="12" class="pt-1">
                 <p class="missing-highlight">
                   <v-icon size="x-large" color="#ff5252" dark>mdi-alert</v-icon>
-                    Missing contact details
+                  Missing contact details
                 </p>
                 <a class="editField" @click="handleOpenEditor">+ email or phone</a>
               </v-col>
@@ -39,14 +43,14 @@
               </v-col>
               <v-col v-if="contact.phoneNumber" cols="12" class="pt-1">
                 <span id="contactPhoneNumber">{{ formatPhoneNumber(contact.phoneNumber) }}</span>
-                <span v-if="contact.phoneExtension"> ext. {{contact.phoneExtension}}</span>
+                <span v-if="contact.phoneExtension"> ext. {{ contact.phoneExtension }}</span>
               </v-col>
               <v-col cols="12" class="pt-1" v-if="contact.alternatePhoneNumber">
                 <span id="contactAlternatePhoneNumber">
                   {{ formatPhoneNumber(contact.alternatePhoneNumber) }} (alt.)
                 </span>
                 <span v-if="contact.alternatePhoneExtension">
-                  ext. {{contact.alternatePhoneExtension}}
+                  ext. {{ contact.alternatePhoneExtension }}
                 </span>
               </v-col>
             </v-row>
@@ -60,7 +64,7 @@
               mdi-calendar-today
             </v-icon>
             <span id="contactEffectiveAndExpiryDate">
-              {{ formatDate(contact.effectiveDate) }} - {{ formatDate(contact.expiryDate)}}
+              {{ formatDate(contact.effectiveDate) }} - {{ formatDate(contact.expiryDate) }}
             </span>
           </v-col>
           <v-col cols="12" class="pt-1" v-else>
@@ -76,8 +80,8 @@
 </template>
 
 <script>
-import {formatPhoneNumber, formatDate, formatContactName} from '../../utils/format';
-import {getStatusColor} from '../../utils/institute/status';
+import { formatPhoneNumber, formatDate, formatContactName } from '../../utils/format';
+import { getStatusColor } from '../../utils/institute/status';
 
 export default {
   name: 'SchoolContact',
@@ -113,9 +117,11 @@ export default {
   color: rgb(0, 51, 102);
   vertical-align: super;
 }
+
 .editField:hover {
   text-decoration: underline;
 }
+
 .missing-highlight {
   color: #ff5252;
   word-break: break-word;

--- a/frontend/src/components/school/SchoolContact.vue
+++ b/frontend/src/components/school/SchoolContact.vue
@@ -4,18 +4,18 @@
       :id="`schoolContactCard-${contact.schoolContactId}`"
       class="schoolContactCard pb-8"
       height="100%">
-      <v-card-title>
+      <v-card-title class="text-wrap">
         <v-row no-gutters>
-          <v-col cols="8">
+          <v-col cols="10">
             <v-icon
               icon="mdi-circle"
               class="pb-1"
               size="x-small"
               :color="getStatusColor(contact)"
               start />
-              <strong style="word-break: break-word;">{{ formatContactName(contact) }}</strong>
+              <strong>{{ formatContactName(contact) }}</strong>
           </v-col>
-          <v-col cols="4" class="d-flex justify-end">
+          <v-col cols="2" class="d-flex justify-end">
             <v-btn
               id="editContactButton"
               title="Edit"

--- a/frontend/src/components/school/SchoolContact.vue
+++ b/frontend/src/components/school/SchoolContact.vue
@@ -2,7 +2,7 @@
   <span>
     <v-card
       :id="`schoolContactCard-${contact.schoolContactId}`"
-      class="schoolContactCard"
+      class="schoolContactCard pb-8"
       height="100%">
       <v-card-title>
         <v-row no-gutters>
@@ -37,16 +37,16 @@
             <br>
             <a class="editField" @click="handleOpenEditor">Add email or phone</a>
           </v-list-item>
-          <v-list-item v-if="contact.email" cols="12" class="pl-0">
+          <v-list-item v-if="contact.email" class="pl-0">
             <v-icon icon="mdi-email" start />
             <span id="contactEmail"> {{ contact.email }}</span>
           </v-list-item>
-          <v-list-item v-if="contact.phoneNumber" cols="12" class="pl-0">
+          <v-list-item v-if="contact.phoneNumber" class="pl-0">
             <v-icon icon="mdi-phone" start />
             <span id="contactPhoneNumber">{{ formatPhoneNumber(contact.phoneNumber) }}</span>
             <span v-if="contact.phoneExtension"> ext. {{ contact.phoneExtension }}</span>
           </v-list-item>
-          <v-list-item cols="12" class="pl-0" v-if="contact.alternatePhoneNumber">
+          <v-list-item class="pl-0" v-if="contact.alternatePhoneNumber">
             <v-icon icon="mdi-phone" start />
             <span id="contactAlternatePhoneNumber">
               {{ formatPhoneNumber(contact.alternatePhoneNumber) }} (alt.)
@@ -55,19 +55,21 @@
               ext. {{ contact.alternatePhoneExtension }}
             </span>
           </v-list-item>
-          <v-list-item cols="12" class="pl-0" v-if="contact.expiryDate">
+        </v-list>
+        <div class="date-container">
+          <div class="pl-0 text-right" v-if="contact.expiryDate">
             <v-icon icon="mdi-calendar-today" size="small" aria-hidden="false" start />
             <span id="contactEffectiveAndExpiryDate" class="text-caption">
               {{ formatDate(contact.effectiveDate) }} - {{ formatDate(contact.expiryDate) }}
             </span>
-          </v-list-item>
-          <v-list-item cols="12" class="pl-0" v-else>
+          </div>
+          <div class="pl-0 text-right" v-else>
             <v-icon icon="mdi-calendar-today" size="small" aria-hidden="false" start />
             <span id="contactEffectiveDate" class="text-caption">
              {{ formatDate(contact.effectiveDate) }}
             </span>
-          </v-list-item>
-        </v-list>
+          </div>
+        </div>
       </v-card-text>
     </v-card>
   </span>
@@ -121,5 +123,10 @@ export default {
   color: #ff5252;
   word-break: break-word;
   font-size: 16px;
+}
+.schoolContactCard { position: relative; }
+.schoolContactCard .date-container {
+  position: absolute;
+  bottom: 1rem; right: 1rem;
 }
 </style>

--- a/frontend/src/components/school/SchoolContact.vue
+++ b/frontend/src/components/school/SchoolContact.vue
@@ -31,11 +31,11 @@
       </v-card-title>
       <v-card-text class="pb-0">
         <v-list density="compact">
-          <v-list-item v-if="!contact.email && !contact.phoneNumber" class="missing-highlight pl-0">
-            <v-icon icon="mdi-alert" size="x-large" color="#ff5252" dark />
-            Missing contact details
-            <br>
-            <a class="editField" @click="handleOpenEditor">Add email or phone</a>
+          <v-list-item v-if="!contact.email && !contact.phoneNumber" class="pl-0">
+            <a class="missing-highlight" @click="handleOpenEditor">
+              <v-icon icon="mdi-alert" size="x-large" color="#ff5252" start />
+              <span>Add missing email or phone</span>
+            </a>
           </v-list-item>
           <v-list-item v-if="contact.email" class="pl-0">
             <v-icon icon="mdi-email" start />
@@ -121,9 +121,8 @@ export default {
 
 .missing-highlight {
   color: #ff5252;
-  word-break: break-word;
-  font-size: 16px;
 }
+.missing-highlight span:hover { text-decoration: underline; }
 .schoolContactCard { position: relative; }
 .schoolContactCard .date-container {
   position: absolute;


### PR DESCRIPTION
I have reworked this component to suit the vue3 along with a couple other upgrades.

Work can be summarized as such:

1. A better separation between `v-card-title` and `v-card-text` content
2. The contact details are a list of information, so I have structurally put them in a `v-list`
3. Removed superfluous `v-col`s and `v-row`s
4. Used padding/positioning to keep the date information distinct from the contact details list
5. Added icons as "bullet points" for the contact details.
6. Fixed word breaking in the `v-card-title`
7. Consolidated the 'missing details' CTA

Things look pretty good on a "normal" contact page

![notwrappy](https://user-images.githubusercontent.com/28788713/223259708-7aafb561-135e-413a-b6db-86e64b0b6a05.PNG)

However when things wrap, it cant get a bit dicey still

![wrappy](https://user-images.githubusercontent.com/28788713/223259976-3e0fb83f-dea9-47a7-a346-f77977af0e29.PNG)

I am open to suggestions :)