### PR TITLE
Fix physical address fields & validation

### DIFF
--- a/frontend/src/components/district/DistrictDetails.vue
+++ b/frontend/src/components/district/DistrictDetails.vue
@@ -599,7 +599,7 @@
                                     dense
                                     label="Same as Mailing Address"
                                     class="mt-n3 pt-0 ml-n3"
-                                    @click="clickSameAsAddressButton"
+                                    @change="clickSameAsAddressButton"
                                   />
                                 </v-col>
                               </v-row>
@@ -819,7 +819,7 @@ export default {
       this.$router.push({name: 'districtContacts', params: {districtID: this.districtID}});
     },
     async clickSameAsAddressButton(){
-      setTimeout(() => this.$refs.districtForm.validate(), 100);
+      await this.$refs.districtForm.validate();
     },
     getMailingAddressItem(item){
       let mailingAddress = this.district.addresses.filter(address => address.addressTypeCode === 'MAILING');

--- a/frontend/src/components/district/DistrictDetails.vue
+++ b/frontend/src/components/district/DistrictDetails.vue
@@ -599,6 +599,7 @@
                                     dense
                                     label="Same as Mailing Address"
                                     class="mt-n3 pt-0 ml-n3"
+                                    @click="clickSameAsAddressButton"
                                   />
                                 </v-col>
                               </v-row>
@@ -672,11 +673,6 @@ export default {
     ...mapState(authStore, ['userInfo']),
     hasSamePhysicalAddress(){
       return !this.district.addresses.filter(address => address.addressTypeCode === 'PHYSICAL').length > 0;
-    }
-  },
-  watch: {
-    sameAsMailingCheckbox() {
-      this.$refs.districtForm.validate();
     }
   },
   created() {
@@ -821,6 +817,9 @@ export default {
     },
     redirectToDistrictContacts(){
       this.$router.push({name: 'districtContacts', params: {districtID: this.districtID}});
+    },
+    async clickSameAsAddressButton(){
+      setTimeout(() => this.$refs.districtForm.validate(), 100);
     },
     getMailingAddressItem(item){
       let mailingAddress = this.district.addresses.filter(address => address.addressTypeCode === 'MAILING');

--- a/frontend/src/components/district/DistrictDetails.vue
+++ b/frontend/src/components/district/DistrictDetails.vue
@@ -819,8 +819,7 @@ export default {
       this.$router.push({name: 'districtContacts', params: {districtID: this.districtID}});
     },
     async clickSameAsAddressButton(){
-      await this.$nextTick();
-      this.$refs.districtForm.validate();
+      setTimeout(() => this.$refs.districtForm.validate(), 100);
     },
     getMailingAddressItem(item){
       let mailingAddress = this.district.addresses.filter(address => address.addressTypeCode === 'MAILING');

--- a/frontend/src/components/district/DistrictDetails.vue
+++ b/frontend/src/components/district/DistrictDetails.vue
@@ -599,7 +599,6 @@
                                     dense
                                     label="Same as Mailing Address"
                                     class="mt-n3 pt-0 ml-n3"
-                                    @click="clickSameAsAddressButton"
                                   />
                                 </v-col>
                               </v-row>
@@ -673,6 +672,11 @@ export default {
     ...mapState(authStore, ['userInfo']),
     hasSamePhysicalAddress(){
       return !this.district.addresses.filter(address => address.addressTypeCode === 'PHYSICAL').length > 0;
+    }
+  },
+  watch: {
+    sameAsMailingCheckbox() {
+      this.$refs.districtForm.validate();
     }
   },
   created() {
@@ -817,9 +821,6 @@ export default {
     },
     redirectToDistrictContacts(){
       this.$router.push({name: 'districtContacts', params: {districtID: this.districtID}});
-    },
-    async clickSameAsAddressButton(){
-      setTimeout(() => this.$refs.districtForm.validate(), 100);
     },
     getMailingAddressItem(item){
       let mailingAddress = this.district.addresses.filter(address => address.addressTypeCode === 'MAILING');

--- a/frontend/src/components/school/EditSchoolContactPage.vue
+++ b/frontend/src/components/school/EditSchoolContactPage.vue
@@ -347,7 +347,6 @@ export default {
     async validateForm() {
       const valid = await this.$refs.editContactForm.validate();
       this.isFormValid = valid.valid;
-      console.log('Validating' + JSON.stringify(valid));
     },
     formatPhoneNumber,
     getStatusColor,

--- a/frontend/src/components/school/SchoolDetails.vue
+++ b/frontend/src/components/school/SchoolDetails.vue
@@ -904,7 +904,7 @@
                                     dense
                                     label="Same as Mailing Address"
                                     class="mt-n3 pt-0 ml-n3"
-                                    @click="clickSameAsAddressButton"
+                                    @change="clickSameAsAddressButton"
                                   />
                                 </v-col>
                               </v-row>
@@ -1160,7 +1160,7 @@ export default {
       return this.userInfo?.activeInstitutePermissions?.filter(perm => perm === 'EDX_USER_SCHOOL_ADMIN').length > 0;
     },
     async clickSameAsAddressButton() {
-      setTimeout(() => this.$refs.schoolDetailsForm.validate(), 100);
+      await this.$refs.schoolDetailsForm.validate();
     },
     async toggleEdit() {
       this.schoolDetailsCopy = this.deepCloneObject(this.school);

--- a/frontend/src/components/school/SchoolDetails.vue
+++ b/frontend/src/components/school/SchoolDetails.vue
@@ -1160,8 +1160,7 @@ export default {
       return this.userInfo?.activeInstitutePermissions?.filter(perm => perm === 'EDX_USER_SCHOOL_ADMIN').length > 0;
     },
     async clickSameAsAddressButton() {
-      await this.$nextTick();
-      this.$refs.schoolDetailsForm.validate();
+      setTimeout(() => this.$refs.schoolDetailsForm.validate(), 100);
     },
     async toggleEdit() {
       this.schoolDetailsCopy = this.deepCloneObject(this.school);

--- a/frontend/src/components/school/SchoolDetails.vue
+++ b/frontend/src/components/school/SchoolDetails.vue
@@ -904,7 +904,6 @@
                                     dense
                                     label="Same as Mailing Address"
                                     class="mt-n3 pt-0 ml-n3"
-                                    @click="clickSameAsAddressButton"
                                   />
                                 </v-col>
                               </v-row>
@@ -1011,6 +1010,11 @@ export default {
     },
     isOffshoreSchool(){
       return this.school.schoolCategoryCode === 'OFFSHORE';
+    }
+  },
+  watch: {
+    sameAsMailingCheckbox() {
+      this.$refs.schoolDetailsForm.validate();
     }
   },
   created() {
@@ -1158,9 +1162,6 @@ export default {
     },
     canEditSchoolDetails(){
       return this.userInfo?.activeInstitutePermissions?.filter(perm => perm === 'EDX_USER_SCHOOL_ADMIN').length > 0;
-    },
-    async clickSameAsAddressButton() {
-      setTimeout(() => this.$refs.schoolDetailsForm.validate(), 100);
     },
     async toggleEdit() {
       this.schoolDetailsCopy = this.deepCloneObject(this.school);

--- a/frontend/src/components/school/SchoolDetails.vue
+++ b/frontend/src/components/school/SchoolDetails.vue
@@ -904,6 +904,7 @@
                                     dense
                                     label="Same as Mailing Address"
                                     class="mt-n3 pt-0 ml-n3"
+                                    @click="clickSameAsAddressButton"
                                   />
                                 </v-col>
                               </v-row>
@@ -1010,11 +1011,6 @@ export default {
     },
     isOffshoreSchool(){
       return this.school.schoolCategoryCode === 'OFFSHORE';
-    }
-  },
-  watch: {
-    sameAsMailingCheckbox() {
-      this.$refs.schoolDetailsForm.validate();
     }
   },
   created() {
@@ -1162,6 +1158,9 @@ export default {
     },
     canEditSchoolDetails(){
       return this.userInfo?.activeInstitutePermissions?.filter(perm => perm === 'EDX_USER_SCHOOL_ADMIN').length > 0;
+    },
+    async clickSameAsAddressButton() {
+      setTimeout(() => this.$refs.schoolDetailsForm.validate(), 100);
     },
     async toggleEdit() {
       this.schoolDetailsCopy = this.deepCloneObject(this.school);

--- a/frontend/src/components/school/SchoolDetails.vue
+++ b/frontend/src/components/school/SchoolDetails.vue
@@ -1047,6 +1047,9 @@ export default {
     redirectToSchoolContacts(){
       this.$router.push({name: 'schoolContacts', params: {schoolID: this.school.schoolId}});
     },
+    setHasSamePhysicalFlag(){
+      this.sameAsMailingCheckbox = this.hasSamePhysicalAddress;
+    },
     getThisSchoolsDetails(){
       this.loading = true;
       this.school = '';
@@ -1169,6 +1172,7 @@ export default {
     },
     cancelClicked(){
       this.editing = false;
+      this.setHasSamePhysicalFlag();
     },
     async updateSchoolDetails() {
       const confirmation = await this.$refs.confirmSchoolDetailsUpdateAndSave.open('Confirm Updates to School Details', null, {color: '#fff', width: 580, closeIcon: false, subtitle: false, dark: false, resolveText: 'Publish Changes', rejectText: 'Return to School Details'});

--- a/frontend/src/components/school/SchoolDetails.vue
+++ b/frontend/src/components/school/SchoolDetails.vue
@@ -165,7 +165,6 @@
                 prepend-icon="mdi-phone-outline"
                 single-line
                 variant="underlined"
-                class="shrink"
                 required
                 :maxlength="10"
                 :rules="[rules.required(), rules.phoneNumber()]"
@@ -230,7 +229,7 @@
                 v-model="schoolDetailsCopy.faxNumber"
                 prepend-icon="mdi-fax"
                 variant="underlined"
-                class="shrink py-0"
+                class="py-0"
                 :rules="[rules.phoneNumber('Fax number must be valid')]"
                 :maxlength="10"
                 @keypress="isNumber($event)"
@@ -625,7 +624,7 @@
                         required
                         :rules="[rules.required()]"
                         :maxlength="255"
-                        class="shrink mt-n5 mb-3"
+                        class="mt-n5 mb-3"
                       />
                     </v-col>
                   </v-row>
@@ -639,7 +638,7 @@
                         v-model="getMailingAddressCopy()[0].addressLine2"
                         variant="underlined"
                         label="Line 2"
-                        class="shrink mt-n3 mb-3"
+                        class="mt-n5 mb-3"
                         :maxlength="255"
                       />
                     </v-col>
@@ -656,7 +655,7 @@
                         label="City"
                         required
                         :rules="[rules.required()]"
-                        class="shrink mt-n5 mb-3"
+                        class="mt-n5 mb-3"
                         :maxlength="255"
                       />
                     </v-col>
@@ -723,7 +722,7 @@
                         :maxlength="6"
                         required
                         :rules="[rules.required(), rules.postalCode()]"
-                        class="shrink mt-n5 mb-3"
+                        class="mt-n5 mb-3"
                       />
                     </v-col>
                   </v-row>
@@ -789,16 +788,14 @@
                     >
                       <span>Same as Mailing Address</span>
                     </v-col>
-                    <v-col
-                      v-else
-                      class="mt-8"
-                    >
+                    <v-col v-else>
                       <v-row no-gutters>
                         <v-col>
                           <v-row no-gutters>
                             <v-col>
                               <v-row
                                 v-if="!sameAsMailingCheckbox"
+                                class="mt-8"
                                 no-gutters
                               >
                                 <v-col>
@@ -812,7 +809,7 @@
                                         required
                                         :rules="[rules.required()]"
                                         :maxlength="255"
-                                        class="shrink mt-n5 mb-3"
+                                        class="mt-n5 mb-3"
                                       />
                                     </v-col>
                                   </v-row>
@@ -824,7 +821,7 @@
                                         :maxlength="255"
                                         variant="underlined"
                                         label="Line 2"
-                                        class="shrink mt-n5 mb-3"
+                                        class="mt-n5 mb-3"
                                       />
                                     </v-col>
                                   </v-row>
@@ -838,7 +835,7 @@
                                         :maxlength="255"
                                         variant="underlined"
                                         label="City"
-                                        class="shrink mt-n5 mb-3"
+                                        class="mt-n5 mb-3"
                                       />
                                     </v-col>
                                   </v-row>
@@ -888,7 +885,7 @@
                                         required
                                         :rules="[rules.required(), rules.postalCode()]"
                                         :maxlength="6"
-                                        class="shrink mt-n5 mb-3"
+                                        class="mt-n5 mb-3"
                                         variant="underlined"
                                         label="Postal Code"
                                       />


### PR DESCRIPTION
This pull request fixes a couple of bugs:

1. The physical address field validation warnings on open for both the student and district details pages.
2. On the district details page, close the physical address fields when the cancel button is clicked.

A couple of these commits make dirty use of `setTimeout()` as it was the only reasonable way I could get the fields to re-validate when they appear in the DOM.  Something changed since upgrading to vue/vuetify 3, and it looks like `this.$refs.<formRef>.validate()` beats the race against `this.$nextTick()`.

I tried re-implementing the form but it ended up being more work than it was probably worth.  I will submit an issue with Vuetify.