### PR TITLE
Fix v-selector elements in contact edit/submission forms

### DIFF
--- a/frontend/src/components/Header.vue
+++ b/frontend/src/components/Header.vue
@@ -3,6 +3,7 @@
     absolute
     color="rgb(0, 51, 102)"
     class="sysBar"
+    style="z-index: 1002;"
     :class="{'pl-2': $vuetify.display.smAndDown, 'pl-10': $vuetify.display.mdAndUp, 'pr-2': $vuetify.display.smAndDown, 'pr-10': $vuetify.display.mdAndUp} "
   >
     <!-- Navbar content -->

--- a/frontend/src/components/common/forms/SchoolContactsForm.vue
+++ b/frontend/src/components/common/forms/SchoolContactsForm.vue
@@ -150,9 +150,9 @@
     </v-navigation-drawer>
   </div>
 </template>
-  
+
 <script>
-  
+
 import ApiService from '../../../common/apiService';
 import {ApiRoutes} from '../../../utils/constants';
 import {PERMISSION} from '../../../utils/constants/Permission';
@@ -162,17 +162,17 @@ import alertMixin from '../../../mixins/alertMixin';
 import {formatPhoneNumber, formatDate, formatContactName} from '../../../utils/format';
 import {getStatusColor} from '../../../utils/institute/status';
 import { sortBy } from 'lodash';
-  
+
 import PrimaryButton from '../../util/PrimaryButton.vue';
 import NewSchoolContactPage from '../../school/NewSchoolContactPage.vue';
 import EditSchoolContactPage from '../../school/EditSchoolContactPage.vue';
 import SchoolContact from '../../school/SchoolContact.vue';
-  
+
 // checks the expiry of a contact
 function isExpired(contact) {
   return (contact.expiryDate) ? new Date(contact.expiryDate) < new Date() : false;
 }
-  
+
 export default {
   name: 'SchoolContactsForm',
   components: {
@@ -302,27 +302,27 @@ export default {
   }
 };
 </script>
-  
+
   <style scoped>
-  
+
   .containerSetup{
     padding-right: 32em !important;
     padding-left: 32em !important;
   }
-  
+
   @media screen and (max-width: 1950px) {
     .containerSetup{
       padding-right: 20em !important;
       padding-left: 20em !important;
     }
   }
-  
+
   @media screen and (max-width: 1200px) {
     .containerSetup{
       padding-right: 4em !important;
       padding-left: 4em !important;
     }
   }
-  
+
   </style>
-  
+

--- a/frontend/src/components/common/forms/SchoolContactsForm.vue
+++ b/frontend/src/components/common/forms/SchoolContactsForm.vue
@@ -116,7 +116,7 @@
       inset
       location="bottom"
       temporary
-      style="width: 50%; height: max-content; left: 25%; z-index: 2001;"
+      style="width: 50%; height: max-content; left: 25%;"
       no-click-animation
       scrollable
       persistent
@@ -136,7 +136,7 @@
       temporary
       no-click-animation
       scrollable
-      style="width: 50%; height: max-content; left: 25%; z-index: 2001;"
+      style="width: 50%; height: max-content; left: 25%;"
       persistent
     >
       <EditSchoolContactPage

--- a/frontend/src/components/common/forms/SchoolContactsForm.vue
+++ b/frontend/src/components/common/forms/SchoolContactsForm.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <v-row v-if="loading">
+    <v-row v-if="isLoading">
       <v-col class="d-flex justify-center">
         <v-progress-circular
           class="mt-16"
@@ -8,11 +8,11 @@
           :width="7"
           color="primary"
           indeterminate
-          :active="loading"
+          :active="isLoading"
         />
       </v-col>
     </v-row>
-    <template v-if="!loading">
+    <template v-if="!isLoading">
       <v-row>
         <v-col
           cols="12"
@@ -209,7 +209,7 @@ export default {
   },
   computed: {
     ...mapState(authStore, ['isAuthenticated','userInfo']),
-    loading() {
+    isLoading() {
       return this.loadingCount !== 0;
     }
   },

--- a/frontend/src/components/district/DistrictContacts.vue
+++ b/frontend/src/components/district/DistrictContacts.vue
@@ -129,8 +129,8 @@
       inset
       no-click-animation
       location="bottom"
-      style="width: 50%; height: max-content; left: 25%; z-index: 2001;"
       temporary
+      style="width: 50%; height: max-content; left: 25%;"
       scrollable
       persistent
     >
@@ -147,7 +147,7 @@
       inset
       no-click-animation
       location="bottom"
-      style="width: 50%; height: max-content; left: 25%; z-index: 2001;"
+      style="width: 50%; height: max-content; left: 25%;"
       temporary
       scrollable
       persistent

--- a/frontend/src/components/util/NavBar.vue
+++ b/frontend/src/components/util/NavBar.vue
@@ -93,6 +93,7 @@
       id="navBar"
       absolute
       color="#38598A"
+      style="z-index: 1001;"
       :dark="true"
       class="pl-4 pr-8"
       :class="{'pl-16': $vuetify.display.mdAndUp}"
@@ -123,7 +124,7 @@
     </v-app-bar>
     <v-app-bar
       v-if="bannerColor !== ''"
-      style="color:white"
+      style="color: white; z-index: 1000;"
       :color="bannerColor"
       absolute
       density="compact"


### PR DESCRIPTION
Jira: EDX-1227
Related: EDX-1193

A word of caution about z-index and v-menu in Vuetify 3:  Setting a higher z-index on a container will break v-menus, as they render menus at the root of the document, way outside of your relative, higher index container.

This pull request addresses both issues in the Jira tickets by _lowering_ the z-index of the v-app-bars instead of raising the modal over-top of them.