### PR TITLE
Fix and improve some secure messaging inbox ui elements

### DIFF
--- a/frontend/src/components/SecureExchange/ExchangeInbox.vue
+++ b/frontend/src/components/SecureExchange/ExchangeInbox.vue
@@ -156,7 +156,6 @@
                         id="statusSelector"
                         v-model="statusSelectFilter"
                         :items="secureExchangeStatusCodes"
-                        prepend-icon="mdi-circle-medium"
                         label="Status"
                         variant="underlined"
                         :menu-props="{
@@ -164,6 +163,11 @@
                           closeOnContentClick: true,
                         }"
                       >
+                        <template #prepend>
+                          <v-icon :color="getStatusColor(statusSelectFilter ? statusSelectFilter[0].label : '')">
+                            mdi-circle-medium
+                          </v-icon>
+                        </template>
                         <template #selection="{ item, index }">
                           {{ item.value.label }}
                         </template>

--- a/frontend/src/components/SecureExchange/ExchangeInbox.vue
+++ b/frontend/src/components/SecureExchange/ExchangeInbox.vue
@@ -107,7 +107,7 @@
                         class="pt-0 mt-0"
                         variant="underlined"
                         label="Subject"
-                        prepend-inner-icon="mdi-book-open-variant"
+                        prepend-icon="mdi-book-open-variant"
                         clearable
                       />
                     </v-col>
@@ -132,7 +132,7 @@
                             class="pt-0 mt-0"
                             variant="underlined"
                             label="Message Date"
-                            prepend-inner-icon="mdi-calendar"
+                            prepend-icon="mdi-calendar"
                             clearable
                             readonly
                             v-bind="attrs"
@@ -156,7 +156,7 @@
                         id="statusSelector"
                         v-model="statusSelectFilter"
                         :items="secureExchangeStatusCodes"
-                        prepend-inner-icon="mdi-circle-medium"
+                        prepend-icon="mdi-circle-medium"
                         label="Status"
                         variant="underlined"
                         :menu-props="{
@@ -193,7 +193,7 @@
                         item-title="teamName"
                         item-value="ministryOwnershipTeamId"
                         :items="ministryContactName"
-                        prepend-inner-icon="mdi-book-open-variant"
+                        prepend-icon="mdi-book-open-variant"
                         clearable
                       />
                     </v-col>
@@ -209,7 +209,7 @@
                         variant="underlined"
                         class="pt-0 mt-0"
                         label="Message ID"
-                        prepend-inner-icon="mdi-pound"
+                        prepend-icon="mdi-pound"
                         clearable
                       />
                     </v-col>
@@ -225,7 +225,7 @@
                         class="pt-0 mt-0"
                         variant="underlined"
                         label="Student PEN"
-                        prepend-inner-icon="mdi-account"
+                        prepend-icon="mdi-account"
                         maxlength="9"
                         counter="9"
                         clearable

--- a/frontend/src/components/SecureExchange/MessageDisplay.vue
+++ b/frontend/src/components/SecureExchange/MessageDisplay.vue
@@ -346,8 +346,7 @@
                                   No
                                 </v-btn>
                                 <v-btn
-                                  dark
-                                  color="#003366"
+                                  color="primary"
                                   @click="removeAttachment(activity.documentID)"
                                 >
                                   Yes
@@ -497,8 +496,7 @@
                                   No
                                 </v-btn>
                                 <v-btn
-                                  dark
-                                  color="#003366"
+                                  color="primary"
                                   @click="removeStudent(activity.secureExchangeStudentId)"
                                 >
                                   Yes

--- a/frontend/src/components/SecureExchange/MessageDisplay.vue
+++ b/frontend/src/components/SecureExchange/MessageDisplay.vue
@@ -277,50 +277,47 @@
                       </v-card-text>
                     </v-card>
                     <v-card v-if="activity.type === 'document'">
-                      <v-row no-gutters>
-                        <v-card-text
-                          class="mt-n2 pb-0"
-                          :class="{'pb-0': activity.documentType.label !== 'Other', 'pb-3': activity.documentType.label === 'Other'}"
+                      <v-card-text
+                        class="mt-n2 pb-0"
+                        :class="{'pb-0': activity.documentType.label !== 'Other', 'pb-3': activity.documentType.label === 'Other'}"
+                      >
+                        <router-link
+                          v-if="isEditable() && isPdf(activity)"
+                          :to="{ path: documentUrl(activity) }"
+                          target="_blank"
                         >
-                          <router-link
-                            v-if="isEditable() && isPdf(activity)"
-                            :to="{ path: documentUrl(activity) }"
-                            target="_blank"
-                          >
-                            {{ activity.fileName }}
-                          </router-link>
-                          <a
-                            v-else-if="isEditable()"
-                            @click="showDocModal(activity)"
-                          >
-                            {{ activity.fileName }}
-                          </a>
-                          <span
-                            v-else
-                            style="color: grey"
-                          >
-                            {{ activity.fileName }}
-                          </span>
-                        </v-card-text>
-                        <v-card-text
-                          v-if="activity.documentType.label !== 'Other'"
-                          class="pt-0 pb-3"
+                          {{ activity.fileName }}
+                        </router-link>
+                        <a
+                          v-else-if="isEditable()"
+                          @click="showDocModal(activity)"
                         >
-                          {{ activity.documentType.label }}
-                        </v-card-text>
+                          {{ activity.fileName }}
+                        </a>
+                        <span
+                          v-else
+                          style="color: grey"
+                        >
+                          {{ activity.fileName }}
+                        </span>
+                      </v-card-text>
+                      <v-card-text
+                        v-if="activity.documentType.label !== 'Other'"
+                        class="pt-0 pb-3"
+                      >
+                        {{ activity.documentType.label }}
+                      </v-card-text>
+                      <v-card-actions v-show="isOpenDocIndex !== index">
+                        <v-spacer />
                         <v-btn
-                          v-show="isOpenDocIndex !== index"
-                          class="ml-12 mb-2 mr-1 pl-0 pr-0 plainBtn"
-                          bottom
-                          right
-                          absolute
+                          density="compact"
                           elevation="0"
                           :disabled="!isEditable()"
                           @click="toggleRemoveDoc(index)"
                         >
                           <v-icon>mdi-delete-forever-outline</v-icon>
                         </v-btn>
-                      </v-row>
+                      </v-card-actions>
                       <v-expand-transition>
                         <div
                           v-show="isOpenDocIndex === index"
@@ -462,20 +459,17 @@
                           </v-col>
                         </v-row>
                       </v-card-text>
-                      <v-row>
+                      <v-card-actions v-show="isOpenStudentIndex !== index">
+                        <v-spacer />
                         <v-btn
-                          v-show="isOpenStudentIndex !== index"
-                          class="ml-12 mr-1 mb-2 pl-0 pr-0 plainBtn"
-                          bottom
-                          right
-                          absolute
+                          density="compact"
                           elevation="0"
                           :disabled="!isEditable()"
                           @click="toggleRemoveStudent(index)"
                         >
                           <v-icon>mdi-delete-forever-outline</v-icon>
                         </v-btn>
-                      </v-row>
+                      </v-card-actions>
                       <v-expand-transition>
                         <div
                           v-show="isOpenStudentIndex === index"


### PR DESCRIPTION
Jira: EDX-1432

Note: I changed the button placement for the delete button a fair bit for the secure exchange trash can icon.  Reason being is the elements used (v-rows) were both incomplete (missing columns) and were not a part of an idiomatic `v-card`.  I made use of the `v-card-actions` instead.

Things align better with buttons and drawer toggles now, but the delete button has its own distinct row:

![image](https://github.com/bcgov/EDUC-EDX/assets/28788713/e01c08ac-a745-4910-a7aa-99b2b420a8ce)

Please see commit messages for granular changes.