### PR TITLE
Add tests for modifying an EDX District User's roles

### DIFF
--- a/frontend/src/components/SecureExchange/AccessUserCard.vue
+++ b/frontend/src/components/SecureExchange/AccessUserCard.vue
@@ -114,6 +114,7 @@
       </div>
       <v-list
         v-else
+        :id="`access-user-roles-${user.edxUserID}`"
         v-model:selected="selectedRoles"
         lines="two"
         return-object
@@ -190,7 +191,10 @@
       >
         <v-row no-gutters>
           <v-col class="d-flex justify-center">
-            <span style="font-size: medium; font-weight: bold; color: black">
+            <span
+              class="accessUserFeedback"
+              style="font-size: medium; font-weight: bold; color: black"
+            >
               Re-linking an account will remove the current user and resend the activation code so
               that the user can set up EDX access with their new credential.
             </span>
@@ -234,7 +238,10 @@
           no-gutters
         >
           <v-col class="mt-0 d-flex justify-start">
-            <p style="font-weight: bolder;color: black;">
+            <p
+              class="accessUserFeedback"
+              style="font-weight: bolder;color: black;"
+            >
               Please select at least one role for {{ user.firstName }}.
             </p>
           </v-col>

--- a/tests-e2e/cypress/e2e/edx-frontend-district/accessDistrictUsers.cy.ts
+++ b/tests-e2e/cypress/e2e/edx-frontend-district/accessDistrictUsers.cy.ts
@@ -37,5 +37,90 @@ describe('Access District Users Page Tests', () => {
         });
       });
     });
+
+    context('with a temporary user', () => {
+      let tempUserId = '';
+      let tempFirstName = '';
+
+      before(() => {
+        cy.task<DistrictUserOptions, EdxUserEntity>('setup-districtUser', {
+          digitalId: crypto.randomUUID(),
+          districtRoles: ['EDX_DISTRICT_ADMIN'],
+          districtCodes: ['998']
+        }).then((user: EdxUserEntity) => {
+            tempUserId = user.edxUserID;
+            tempFirstName = user.firstName;
+          });
+      });
+      beforeEach(() => {
+        cy.wrap(tempUserId).as('tempUserId');
+        cy.wrap(tempFirstName).as('tempUserFirstName');
+      });
+      after(() => cy.get('@tempUserId').then(uid => cy.task('teardown-edxUser', uid)));
+
+      it('will not save a user with no roles', () => {
+        cy.visit('/districtAccess', {timeout: 3000});
+        cy.get('@tempUserId').then(uid => {
+          cy.get(`#edxUser-${uid}`).should('exist');
+          cy.get(`#user-edit-button-${uid}`).click();
+          cy.get(`#access-user-roles-${uid}`).should('exist').within(() => {
+            cy.get('div[value="EDX_DISTRICT_ADMIN"]').click();
+          });
+          cy.get('@tempUserFirstName').then(fname => {
+            cy.get(selectors.accessUsersPage.accessUserFeedback)
+              .should('include.text', `Please select at least one role for ${fname}`);
+          });
+          cy.get(`#user-save-action-button-${uid}`).should('be.disabled');
+        });
+      });
+
+      it('can cancel the edit user mode', () => {
+        cy.visit('/districtAccess', {timeout:3000});
+        cy.get('@tempUserId').then(uid => {
+          cy.get(`#user-edit-button-${uid}`).click();
+          cy.get(`#user-cancel-edit-button-${uid}`).should('exist').click();
+          cy.get(`#access-user-roles-${uid}`).should('not.exist');
+          cy.get(`#user-edit-button-${uid}`).click().click({timeout:200});
+          cy.get(`#access-user-roles-${uid}`).should('not.exist');
+        });
+      });
+
+      it('will only permit one role', () => {
+        cy.visit('/districtAccess', {timeout: 3000});
+        cy.get('@tempUserId').then(uid => {
+          cy.get(`#user-edit-button-${uid}`).click();
+          cy.get(`#access-user-roles-${uid}`).should('exist').within(() => {
+            cy.get('div[value="SECURE_EXCHANGE_DISTRICT"] > .v-list-item')
+              .should('have.class', 'v-list-item--disabled');
+            cy.get('div[value="EDX_DISTRICT_ADMIN"]').click();
+            cy.get('div[value="SECURE_EXCHANGE_DISTRICT"] input').click().should('be.checked');
+            cy.get('div[value="EDX_DISTRICT_ADMIN"] > .v-list-item').should('not.have.class', '.v-list-item--disabled');
+            cy.get('div[value="EDX_DISTRICT_ADMIN"]').click();
+            cy.get('div[value="SECURE_EXCHANGE_DISTRICT"] input').should('not.be.checked');
+            cy.get('div[value="EDX_DISTRICT_ADMIN"] > .v-list-item').should('not.have.class', '.v-list-item--disabled');
+          });
+        });
+      });
+
+      it('can update the user\'s role', () => {
+        cy.visit('/districtAccess', {timeout:3000});
+        cy.get('@tempUserId').then(uid => {
+          cy.get(`#user-edit-button-${uid}`).click();
+          cy.get(`#access-user-roles-${uid}`).should('exist').within(() => {
+            cy.get('div[value="EDX_DISTRICT_ADMIN"]').click();
+            cy.get('div[value="SECURE_EXCHANGE_DISTRICT"]').click();
+          });
+          cy.get(`#user-save-action-button-${uid}`).should('not.be.disabled').click();
+          cy.get(selectors.snackbar.mainSnackBar).should('include.text', 'User roles have been updated. Close');
+          cy.get(`#access-user-roles-${uid}`, {timeout: 3000}).should('not.exist');
+          cy.get(`#user-edit-button-${uid}`).click();
+          cy.get(`#access-user-roles-${uid}`).should('exist').within(() => {
+            cy.get('div[value="EDX_DISTRICT_ADMIN"] input').should('not.be.checked');
+            cy.get('div[value="SECURE_EXCHANGE_DISTRICT"] input').should('be.checked');
+          });
+        });
+      })
+
+    });
   });
 });

--- a/tests-e2e/cypress/support/selectors.ts
+++ b/tests-e2e/cypress/support/selectors.ts
@@ -2,7 +2,8 @@ export default {
   accessUsersPage: {
     manageSchoolButton: '#manageSchoolButton',
     schoolSelectorBox: 'div[role="listbox"]',
-    selectSchoolDropdown: '#selectInstituteName'
+    selectSchoolDropdown: '#selectInstituteName',
+    accessUserFeedback: '.accessUserFeedback'
   },
   dashboard: {
     dataCollectionsTile: '#studentDataCollectionCard',


### PR DESCRIPTION
Jira: EDX-587

Note: The funny pattern for aliasing the district user's ID and first name is due to how Cypress scrubs aliases after every test.  They need to be re-set up before each test. Related: https://github.com/cypress-io/cypress/issues/665