### PR TITLE
fix: DocumentUpload state not clearing on submit

### DIFF
--- a/frontend/src/components/SecureExchange/NewMessagePage.vue
+++ b/frontend/src/components/SecureExchange/NewMessagePage.vue
@@ -186,7 +186,7 @@
                     <v-col class="d-flex justify-center px-2 pb-2 pt-2">
                       <v-expand-transition>
                         <DocumentUpload
-                          v-show="expandAttachFile"
+                          v-if="expandAttachFile"
                           :allowed-file-format="formatMessage"
                           @close:form="showOptions"
                           @upload="uploadDocument"

--- a/frontend/src/components/common/DocumentUpload.vue
+++ b/frontend/src/components/common/DocumentUpload.vue
@@ -139,18 +139,7 @@ export default {
       return false;
     },
     closeForm() {
-      this.resetForm();
       this.$emit('close:form');
-    },
-    resetForm() {
-      this.$refs.documentForm.reset();
-      this.fileInputError = [];
-      this.uploadFileValue = null;
-      this.alert = false;
-      this.active = false;
-      this.alertMessage = null;
-      this.documentTypeCode = null;
-      this.validateForm();
     },
     setSuccessAlert() {
       this.alertMessage = 'File upload successful.';
@@ -208,7 +197,6 @@ export default {
         documentData: btoa(env.target.result)
       };
       this.$emit('upload', document);
-      this.resetForm();
       this.$emit('close:form');
     },
     makefileFormatList(extensions) {


### PR DESCRIPTION
The use of v-show allowed for some sort of async state collision.  The simplest solution is to tear the component down on cancel or submit. This makes the "resetForm" method redundant.

Jira: EDX-1609