### PR TITLE
fix: searching category with no results showing success

### DIFF
--- a/frontend/src/components/sdcCollection/stepTwoValidateData/StepTwoViewDataIssues.vue
+++ b/frontend/src/components/sdcCollection/stepTwoValidateData/StepTwoViewDataIssues.vue
@@ -104,7 +104,7 @@
     </v-row>
     <v-row>
       <v-col
-        v-if="studentListData?.length > 0"
+        v-if="numIssueStudentsInCollection > 0"
         class="pr-0"
       >
         <v-row class="searchBox">
@@ -179,7 +179,9 @@
         <v-row
           class="pt-3 pb-3"
         >
-          <v-col class="text-right">
+          <v-col class="text-right"
+            v-if="studentListData?.length > 0"
+          >
             <PrimaryButton
               id="fixSelected"
               text="Review & Fix Selected"
@@ -195,6 +197,23 @@
               :click-action="getAllIssuesAndNavigate"
               :disabled="selectedStudents.length != 0"
             />
+          </v-col>
+          <v-col class="mr-3"
+            v-else
+          >
+            <v-alert
+              dismissible="false"
+              class="clear-message-error"
+            >
+              <v-icon
+                class="mt-2 mr-3"
+                size="30"
+                color="orange"
+              >
+                mdi-alert-outline
+              </v-icon>
+              <span class="error-message">There are no results for the selected category.</span>
+            </v-alert>
           </v-col>
         </v-row>
         <v-row>
@@ -575,6 +594,13 @@ export default {
     .clear-message {
       border: 1px solid darkgreen;
       color: darkgreen;
+      background-color: transparent;
+      padding: 10px;
+    }
+
+    .clear-message-error {
+      border: 1px solid orange;
+      color: orange;
       background-color: transparent;
       padding: 10px;
     }

--- a/frontend/src/components/sdcCollection/stepTwoValidateData/StepTwoViewDataIssues.vue
+++ b/frontend/src/components/sdcCollection/stepTwoValidateData/StepTwoViewDataIssues.vue
@@ -592,17 +592,17 @@ export default {
     }
   
     .clear-message {
-      border: 1px solid darkgreen;
+      border: 0.05em solid darkgreen;
       color: darkgreen;
       background-color: transparent;
-      padding: 10px;
+      padding: 0.6em;
     }
 
     .clear-message-error {
-      border: 1px solid orange;
+      border: 0.05em solid orange;
       color: orange;
       background-color: transparent;
-      padding: 10px;
+      padding: 0.6em;
     }
   
    .inner-border {


### PR DESCRIPTION
Repro:

When reviewing and fixing student data issues in a school data collection, if the user entered a category that returned no students it would display a success message 'Congratulations! There are no errors or warnings in the 1701 Submission'.
Fix:

If category filter has no results but there are still data issues, shows an empty table and error message 'There are no results for the selected category.'.
If all data issues are resolved, displays the 'Congratulations! There are no errors or warnings in the 1701 Submission.' success alert.