### PR TITLE
Fix for 2915.

### DIFF
--- a/frontend/src/components/common/CustomTable.vue
+++ b/frontend/src/components/common/CustomTable.vue
@@ -23,7 +23,7 @@
             id="header"
             :key="column.key"
           >
-            <div v-if="column.title === 'select' && schoolCollection?.sdcSchoolCollectionStatusCode !== 'SUBMITTED'">
+            <div v-if="column.title === 'select' && schoolCollection?.sdcSchoolCollectionStatusCode !== 'SUBMITTED' && !disableSelect">
               <v-checkbox
                 v-model="masterCheckbox"
                 :indeterminate="selected.length > 0 && !isAllSelected()"
@@ -67,7 +67,7 @@
             class="td-data"
           >
             <v-checkbox
-              v-if="column.title === 'select' && schoolCollection?.sdcSchoolCollectionStatusCode !== 'SUBMITTED'"
+              v-if="column.title === 'select' && schoolCollection?.sdcSchoolCollectionStatusCode !== 'SUBMITTED' && !disableSelect"
               :model-value="isSelected(props.item) !== undefined"
               hide-details="true"
               @click.prevent.stop="onClick(props)"
@@ -226,6 +226,11 @@ export default {
       type: Object,
       required: false,
       default: null
+    },
+    disableSelect: {
+      type: Boolean,
+      required: false,
+      default: false
     }
   },
   emits: ['reload', 'editSelectedRow', 'selections'],

--- a/frontend/src/components/common/SignOffSignatures.vue
+++ b/frontend/src/components/common/SignOffSignatures.vue
@@ -41,7 +41,7 @@
               width="90%"
               :text="data.buttonText"
               class="mt-3 mb-3"
-              :disabled="data.isDisabled"
+              :disabled="data.isDisabled || !isCollectionActive"
               @click="submit(data)"
             />
           </td>
@@ -93,6 +93,10 @@ export default {
       required: true,
       default: null
     },
+    isCollectionActive: {
+      type: Boolean,
+      required: true
+    }
   },
   emits: [],
   data() {

--- a/frontend/src/components/common/StudentDetail.vue
+++ b/frontend/src/components/common/StudentDetail.vue
@@ -131,7 +131,7 @@
     </v-col>
 
     <v-col cols="3">
-      <span class="label">Special Ed Category:</span>
+      <span class="label">Inclusive Ed Category:</span>
     </v-col>
     <v-col cols="3">
       {{ student?.mappedSpedCode }}

--- a/frontend/src/components/sdcCollection/sdcDistrictCollection/stepThreeVerifyData/AllStudentsComponent.vue
+++ b/frontend/src/components/sdcCollection/sdcDistrictCollection/stepThreeVerifyData/AllStudentsComponent.vue
@@ -32,6 +32,7 @@
         :district="district"
         :show-export-btn="true"
         :is-final-sign-off="isFinalSignOff"
+        :is-collection-active="isCollectionActive"
       />
     </div>
     <div v-if="reportView === 'summary'">

--- a/frontend/src/components/sdcCollection/sdcDistrictCollection/stepThreeVerifyData/CareerProgramsComponent.vue
+++ b/frontend/src/components/sdcCollection/sdcDistrictCollection/stepThreeVerifyData/CareerProgramsComponent.vue
@@ -31,6 +31,7 @@
         :config="config"
         :district="district"
         :is-final-sign-off="isFinalSignOff"
+        :is-collection-active="isCollectionActive"
       />
     </div>
     <div v-if="reportView === 'summary'">

--- a/frontend/src/components/sdcCollection/sdcDistrictCollection/stepThreeVerifyData/DetailComponent.vue
+++ b/frontend/src/components/sdcCollection/sdcDistrictCollection/stepThreeVerifyData/DetailComponent.vue
@@ -54,6 +54,7 @@
             :total-elements="totalElements"
             :is-loading="isLoading"
             :reset="resetFlag"
+            :disable-select="!isCollectionActive"
             @reload="reload"
             @editSelectedRow="editStudent"
             @selections="selectedStudents = $event"
@@ -161,6 +162,11 @@ export default {
     isFinalSignOff: {
       type: Boolean,
       required: false
+    },
+    isCollectionActive: {
+      type: Boolean,
+      required: true,
+      default: false
     }
   },
   emits: [],

--- a/frontend/src/components/sdcCollection/sdcDistrictCollection/stepThreeVerifyData/EnglishLangComponent.vue
+++ b/frontend/src/components/sdcCollection/sdcDistrictCollection/stepThreeVerifyData/EnglishLangComponent.vue
@@ -31,6 +31,7 @@
         :config="config"
         :district="district"
         :is-final-sign-off="isFinalSignOff"
+        :is-collection-active="isCollectionActive"
       />
     </div>
     <div v-if="reportView === 'summary'">

--- a/frontend/src/components/sdcCollection/sdcDistrictCollection/stepThreeVerifyData/FrenchProgramsComponent.vue
+++ b/frontend/src/components/sdcCollection/sdcDistrictCollection/stepThreeVerifyData/FrenchProgramsComponent.vue
@@ -31,6 +31,7 @@
         :config="config"
         :district="district"
         :is-final-sign-off="isFinalSignOff"
+        :is-collection-active="isCollectionActive"
       />
     </div>
     <div v-if="reportView === 'summary'">

--- a/frontend/src/components/sdcCollection/sdcDistrictCollection/stepThreeVerifyData/IndSupportProgramsComponent.vue
+++ b/frontend/src/components/sdcCollection/sdcDistrictCollection/stepThreeVerifyData/IndSupportProgramsComponent.vue
@@ -31,6 +31,7 @@
         :config="config"
         :district="district"
         :is-final-sign-off="isFinalSignOff"
+        :is-collection-active="isCollectionActive"
       />
     </div>
     <div v-if="reportView === 'summary'">

--- a/frontend/src/components/sdcCollection/sdcDistrictCollection/stepThreeVerifyData/RefugeeComponent.vue
+++ b/frontend/src/components/sdcCollection/sdcDistrictCollection/stepThreeVerifyData/RefugeeComponent.vue
@@ -31,6 +31,7 @@
         :config="config"
         :district="district"
         :is-final-sign-off="isFinalSignOff"
+        :is-collection-active="isCollectionActive"
       />
     </div>
     <div v-if="reportView === 'summary'">

--- a/frontend/src/components/sdcCollection/sdcDistrictCollection/stepThreeVerifyData/SpecialEduComponent.vue
+++ b/frontend/src/components/sdcCollection/sdcDistrictCollection/stepThreeVerifyData/SpecialEduComponent.vue
@@ -32,6 +32,7 @@
         :config="config"
         :district="district"
         :is-final-sign-off="isFinalSignOff"
+        :is-collection-active="isCollectionActive"
       />
     </div>
     <div v-if="reportView === 'summary'">

--- a/frontend/src/components/sdcCollection/sdcDistrictCollection/stepThreeVerifyData/StepThreeVerifyData.vue
+++ b/frontend/src/components/sdcCollection/sdcDistrictCollection/stepThreeVerifyData/StepThreeVerifyData.vue
@@ -156,6 +156,7 @@
         <SignOffSignatures
           :district="district"
           :district-collection-object="districtCollectionObject"
+          :is-collection-active="isCollectionActive"
         />
       </v-window-item>
     </v-window> 

--- a/frontend/src/components/sdcCollection/sdcSchoolCollection/stepThreeVerifyData/CareerProgramsComponent.vue
+++ b/frontend/src/components/sdcCollection/sdcSchoolCollection/stepThreeVerifyData/CareerProgramsComponent.vue
@@ -31,6 +31,7 @@
         :config="config"
         :school="school"
         :is-final-sign-off="isFinalSignOff"
+        :is-collection-active="isCollectionActive"
       />
     </div>
     <div v-if="reportView === 'summary'">

--- a/frontend/src/components/sdcCollection/sdcSchoolCollection/stepThreeVerifyData/DetailComponent.vue
+++ b/frontend/src/components/sdcCollection/sdcSchoolCollection/stepThreeVerifyData/DetailComponent.vue
@@ -32,6 +32,7 @@
           class="d-flex justify-end"
         >
           <v-btn
+            v-if="isCollectionActive"
             id="add"
             color="#003366"
             text="Add Student"
@@ -42,6 +43,7 @@
             @click="addStudent"
           />
           <v-btn
+            v-if="isCollectionActive"
             id="remove"
             color="#003366"
             class="mr-1 mb-1"
@@ -80,7 +82,8 @@
             :total-elements="totalElements"
             :is-loading="isLoading"
             :reset="resetFlag"
-            :school-collection="schoolCollection"
+            :school-collection="schoolCollection" 
+            :disable-select="!isCollectionActive"           
             @reload="reload"
             @editSelectedRow="editStudent"
             @selections="selectedStudents = $event"
@@ -187,6 +190,11 @@ export default {
     isFinalSignOff: {
       type: Boolean,
       required: false
+    },
+    isCollectionActive: {
+      type: Boolean,
+      required: true,
+      default: false
     }
   },
   emits: [],

--- a/frontend/src/components/sdcCollection/sdcSchoolCollection/stepThreeVerifyData/EnglishLangComponent.vue
+++ b/frontend/src/components/sdcCollection/sdcSchoolCollection/stepThreeVerifyData/EnglishLangComponent.vue
@@ -31,6 +31,7 @@
         :config="config"
         :school="school"
         :is-final-sign-off="isFinalSignOff"
+        :is-collection-active="isCollectionActive"
       />
     </div>
     <div v-if="reportView === 'summary'">

--- a/frontend/src/components/sdcCollection/sdcSchoolCollection/stepThreeVerifyData/FTEComponent.vue
+++ b/frontend/src/components/sdcCollection/sdcSchoolCollection/stepThreeVerifyData/FTEComponent.vue
@@ -32,6 +32,7 @@
         :config="config"
         :show-export-btn="true"
         :is-final-sign-off="isFinalSignOff"
+        :is-collection-active="isCollectionActive"
       />
     </div>
     <div v-if="reportView === 'summary'">

--- a/frontend/src/components/sdcCollection/sdcSchoolCollection/stepThreeVerifyData/FrenchProgramsComponent.vue
+++ b/frontend/src/components/sdcCollection/sdcSchoolCollection/stepThreeVerifyData/FrenchProgramsComponent.vue
@@ -31,6 +31,7 @@
         :config="config"
         :school="school"
         :is-final-sign-off="isFinalSignOff"
+        :is-collection-active="isCollectionActive"
       />
     </div>
     <div v-if="reportView === 'summary'">

--- a/frontend/src/components/sdcCollection/sdcSchoolCollection/stepThreeVerifyData/IndSupportProgramsComponent.vue
+++ b/frontend/src/components/sdcCollection/sdcSchoolCollection/stepThreeVerifyData/IndSupportProgramsComponent.vue
@@ -31,6 +31,7 @@
         :config="config"
         :school="school"
         :is-final-sign-off="isFinalSignOff"
+        :is-collection-active="isCollectionActive"
       />
     </div>
     <div v-if="reportView === 'summary'">

--- a/frontend/src/components/sdcCollection/sdcSchoolCollection/stepThreeVerifyData/RefugeeComponent.vue
+++ b/frontend/src/components/sdcCollection/sdcSchoolCollection/stepThreeVerifyData/RefugeeComponent.vue
@@ -22,6 +22,7 @@
         :config="config"
         :school="school"
         :is-final-sign-off="isFinalSignOff"
+        :is-collection-active="isCollectionActive"
       />
     </div>
   </v-container>

--- a/frontend/src/components/sdcCollection/sdcSchoolCollection/stepThreeVerifyData/SpecialEduComponent.vue
+++ b/frontend/src/components/sdcCollection/sdcSchoolCollection/stepThreeVerifyData/SpecialEduComponent.vue
@@ -32,6 +32,7 @@
         :config="config"
         :school="school"
         :is-final-sign-off="isFinalSignOff"
+        :is-collection-active="isCollectionActive"
       />
     </div>
     <div v-if="reportView === 'summary'">


### PR DESCRIPTION
Change Details:

School collection
- For non-active collection we are disabling the "Add Student" functionality
- For non-active collections we are disabling the "Remove" functionality and also the hide checkbox in "CustomTable".

District collection
- For non-active collection; we will disable the "Sign-Off Actions" despite the fact whether it is signed or not
- For non-active collections we are hiding the checkbox in "CustomTable".

Changed the keyword "Special Ed"  to "Inclusive Ed"