### PR TITLE
hd-32532 prevent user from sending new message before they attach a s…

### DIFF
--- a/frontend/src/components/SecureExchange/NewMessagePage.vue
+++ b/frontend/src/components/SecureExchange/NewMessagePage.vue
@@ -229,7 +229,7 @@
             id="newMessagePostBtn"
             text="Send"
             width="7rem"
-            :disabled="!isValidForm || fileSizeAlert"
+            :disabled="!isValidForm || fileSizeAlert || expandAddStudent || expandAttachFile"
             :loading="processing"
             :click-action="sendNewMessage"
           />


### PR DESCRIPTION
…tudent or message.

Can send message when it's complete
<img width="1344" height="665" alt="image" src="https://github.com/user-attachments/assets/831632e7-f4c2-4dfe-a770-a038b768656e" />

Cannot send message when in the middle of attaching file 
<img width="1333" height="932" alt="image" src="https://github.com/user-attachments/assets/83dd6941-d7d9-4c1f-918b-14a6c35ceaa3" />

Cannot send message when in the middle of adding student
<img width="1328" height="765" alt="image" src="https://github.com/user-attachments/assets/c2d12813-d90a-4c31-b08a-dad7de536d29" />
